### PR TITLE
Correct bulk feature calculations - 6 features affected.

### DIFF
--- a/src/main/java/cic/cs/unb/ca/jnetpcap/BasicFlow.java
+++ b/src/main/java/cic/cs/unb/ca/jnetpcap/BasicFlow.java
@@ -145,6 +145,16 @@ public class BasicFlow {
     }
 
     public void firstPacket(BasicPacketInfo packet) {
+        
+        if (this.src == null) {
+            this.src = packet.getSrc();
+            this.srcPort = packet.getSrcPort();
+        }
+        if (this.dst == null) {
+            this.dst = packet.getDst();
+            this.dstPort = packet.getDstPort();
+        }
+
         updateFlowBulk(packet);
 
         checkFlags(packet);
@@ -155,14 +165,6 @@ public class BasicFlow {
         detectUpdateSubflows(packet);
         this.flowLengthStats.addValue((double) packet.getPayloadBytes());
 
-        if (this.src == null) {
-            this.src = packet.getSrc();
-            this.srcPort = packet.getSrcPort();
-        }
-        if (this.dst == null) {
-            this.dst = packet.getDst();
-            this.dstPort = packet.getDstPort();
-        }
         if (Arrays.equals(this.src, packet.getSrc())) {
             this.min_seg_size_forward = packet.getHeaderBytes();
             Init_Win_bytes_forward = packet.getTCPWindow();
@@ -397,13 +399,11 @@ public class BasicFlow {
     }
 
     public void updateFlowBulk(BasicPacketInfo packet) {
-
-        if (this.src == packet.getSrc()) {
+        if (Arrays.equals(this.src, packet.getSrc())) {
             updateForwardBulk(packet, blastBulkTS);
         } else {
-            updateBackwardBulk(packet, flastBulkTS);
+            updateBackwardBulk(packet,flastBulkTS);
         }
-
     }
 
     public void updateForwardBulk(BasicPacketInfo packet, long tsOflastBulkInOther) {


### PR DESCRIPTION
I tracked down the issue raised in https://github.com/GintsEngelen/WTMC2021-Code/issues/1. The ports are represented as byte arrays and the comparison in the original form is incorrect (memory locations vs byte array values). This means the backward and forward bulk calculations were lumped into the backward bulk calculations. This has implications for 6 features:

- Fwd Avg Bytes
- Fwd Avg Packets
- Fwd Avg Bulk Rate
- Bwd Avg Bytes
- Bwd Avg Packets
- Bwd Avg Bulk Rate


It may be in your interest to regenerate the flows with the correct/intended values.















































































