### PR TITLE
Correct down/up ratio calculation

### DIFF
--- a/src/main/java/cic/cs/unb/ca/jnetpcap/BasicFlow.java
+++ b/src/main/java/cic/cs/unb/ca/jnetpcap/BasicFlow.java
@@ -284,7 +284,7 @@ public class BasicFlow {
 
     public double getDownUpRatio() {
         if (this.forward.size() > 0) {
-            return (double) (this.backward.size() / this.forward.size());
+            return ((double)this.backward.size())/this.forward.size();
         }
         return 0;
     }


### PR DESCRIPTION
I noticed that all the down/up ratio values were either 0 or 1. Tracking back to the code, the backward.size() is an int, and this.forward.size() is an int. int/int = int. 

I believe the original author intended to return a proper ratio (double return type), but it doesn't look like they correctly cast one of the values to a double so to ensure correct calculation; instead they casted the value returned by integer division to a double.