### PR TITLE
Re-add syn flag to detect start of new flow

### DIFF
--- a/src/main/java/cic/cs/unb/ca/jnetpcap/FlowGenerator.java
+++ b/src/main/java/cic/cs/unb/ca/jnetpcap/FlowGenerator.java
@@ -91,7 +91,7 @@ public class FlowGenerator {
             // 2.- we eliminate the flow from the current flow list
             // 3.- we create a new flow with the packet-in-process
             if ((currentTimestamp - flow.getFlowStartTime()) > flowTimeOut ||
-                    (flow.getTcpFlowState() == TcpFlowState.READY_FOR_TERMINATION)) {
+                    ((flow.getTcpFlowState() == TcpFlowState.READY_FOR_TERMINATION) && packet.hasFlagSYN())) {
 
                 // set cumulative flow time if TCP packet
                 if (flow.getProtocol() == ProtocolEnum.TCP) {
@@ -109,7 +109,9 @@ public class FlowGenerator {
                 currentFlows.remove(id);
 
                 // If the original flow is set for termination, or the flow is not a tcp connection, create a new flow
-                if ((flow.getTcpFlowState() == TcpFlowState.READY_FOR_TERMINATION) || packet.getProtocol() != ProtocolEnum.TCP) {
+                // Having a SYN packet and no ACK packet means it's the first packet in a new flow
+                if (((flow.getTcpFlowState() == TcpFlowState.READY_FOR_TERMINATION) && packet.hasFlagSYN() && !packet.hasFlagACK())
+                        || packet.getProtocol() != ProtocolEnum.TCP) {
                     // create new flow, don't switch direction
                     currentFlows.put(id, new BasicFlow(bidirectional,packet,packet.getSrc(),packet.getDst(),packet.getSrcPort(),
                     packet.getDstPort(), this.flowActivityTimeOut));


### PR DESCRIPTION
The conversation logic for TCP in wireshark can be found: https://github.com/boundary/wireshark/blob/07eade8124fd1d5386161591b52e177ee6ea849f/epan/dissectors/packet-tcp.c

Roughly, 4115:

/* If this is a SYN packet, then check if its seq-nr is different
     * from the base_seq of the retrieved conversation. If this is the
     * case, create a new conversation with the same addresses and ports
     * and set the TA_PORTS_REUSED flag. If the seq-nr is the same as
     * the base_seq, then do nothing so it will be marked as a retrans-
     * mission later.
     */

Accordingly, I've re-added the syn check to complete the last flow and start a new flow. This means a new flow shouldn't start until a new 'SYN' packet has been received, and flows that have been officially terminated, will have orphaned packets that will be added to that flow in it was not gracefully terminated.