### PR TITLE
Non-blocking time order verification + Packet ID of first disordered packet

### DIFF
--- a/src/main/java/cic/cs/unb/ca/ifm/Cmd.java
+++ b/src/main/java/cic/cs/unb/ca/ifm/Cmd.java
@@ -132,9 +132,10 @@ public class Cmd {
         int nValid=0;
         int nTotal=0;
         int nDiscarded = 0;
-        long previousTimestamp = 0;
-        long currentTimestamp = 0;
+        long previousTimestamp = 0L;
+        long currentTimestamp = 0L;
         boolean disordered = false;
+        long idDisorderedPacket = 0L;
         long start = System.currentTimeMillis();
         int i=0;
         while(true) {
@@ -148,9 +149,17 @@ public class Cmd {
                     // Check that pcap file isn't disordered to make sure to obtain consistent network flows.
                     //
                     currentTimestamp = basicPacket.getTimeStamp();
-                    if(previousTimestamp>currentTimestamp){
+                    if(!(disordered) && (previousTimestamp>currentTimestamp)){
+                        idDisorderedPacket = basicPacket.getId(); // save ID of the first disordered packet.
                         disordered = true;
-                        break;
+
+                        // The pcap file is disordered thus show the warning to user            
+                        System.out.println(DividingLine);
+                        System.out.println("/!\\ The pcap file contains disordered packets ! The network flows may be incorrect.");
+                        System.out.println(String.format("The packet with ID %d is the first disordered one.", idDisorderedPacket));
+                        System.out.println("Please order your pcap file and run the tool again.");
+                        System.out.println(DividingLine);
+
                     }else{
                         previousTimestamp = currentTimestamp;
                     }
@@ -166,21 +175,13 @@ public class Cmd {
             i++;
         }
 
-        if(disordered){
-            // The pcap file is disordered don't export network flows.
-            System.out.println("/!\\ The pcap file contains disordered packets ! The network flows may be incorrect.");
-            System.out.println("Please order your pcap file and run the tool again.");
-            System.out.println(DividingLine);
-        }else{
-            // the pcap file is well ordered continue and save network flows.
+        flowGen.dumpLabeledCurrentFlow(saveFileFullPath.getPath(), FlowFeature.getHeader());
 
-            flowGen.dumpLabeledCurrentFlow(saveFileFullPath.getPath(), FlowFeature.getHeader());
+        long lines = SwingUtils.countLines(saveFileFullPath.getPath());
 
-            long lines = SwingUtils.countLines(saveFileFullPath.getPath());
-
-            System.out.println(String.format("%s is done. total %d flows ",fileName,lines));
-            System.out.println(String.format("Packet stats: Total=%d,Valid=%d,Discarded=%d",nTotal,nValid,nDiscarded));
-            System.out.println(DividingLine);
+        System.out.println(String.format("%s is done. total %d flows ",fileName,lines));
+        System.out.println(String.format("Packet stats: Total=%d,Valid=%d,Discarded=%d",nTotal,nValid,nDiscarded));
+        System.out.println(DividingLine);
         
         //long end = System.currentTimeMillis();
         //logger.info(String.format("Done! in %d seconds",((end-start)/1000)));
@@ -192,7 +193,6 @@ public class Cmd {
         //logger.info(String.format("Number of Flows: %d",singleTotal));
         //logger.info("{} is done,Total {} flows",inputFile,singleTotal);
         //System.out.println(String.format("%s is done,Total %d flows", inputFile, singleTotal));
-        }
     }
 
     static class FlowListener implements FlowGenListener {


### PR DESCRIPTION
As requested in the previous pull-request (https://github.com/GintsEngelen/CICFlowMeter/pull/8), I added the packet ID in the warning to the user to know where is located the first disordered packet. 

I also made the time order verification non-blocking so that the warning is shown but the wrong output is still exported.