### PR TITLE
Init bwd win byte bug

### DIFF
--- a/src/main/java/cic/cs/unb/ca/jnetpcap/BasicFlow.java
+++ b/src/main/java/cic/cs/unb/ca/jnetpcap/BasicFlow.java
@@ -247,7 +247,12 @@ public class BasicFlow {
                 }
             } else {
                 this.bwdPktStats.addValue((double) packet.getPayloadBytes());
-                Init_Win_bytes_backward = packet.getTCPWindow();
+                // set Init_win_bytes_backward if not been set. The set logic isn't 100%
+                // accurate, since it technically takes the first non-zero value, but should
+                // be good enough for most cases.
+                if (Init_Win_bytes_backward == 0) {
+                    Init_Win_bytes_backward = packet.getTCPWindow();
+                }
                 this.bHeaderBytes += packet.getHeaderBytes();
                 this.backward.add(packet);
                 this.backwardBytes += packet.getPayloadBytes();

--- a/src/main/java/cic/cs/unb/ca/jnetpcap/BasicFlow.java
+++ b/src/main/java/cic/cs/unb/ca/jnetpcap/BasicFlow.java
@@ -408,7 +408,7 @@ public class BasicFlow {
             sfAcHelper = packet.getTimeStamp();
         }
         //System.out.print(" - "+(packet.timeStamp - sfLastPacketTS));
-        if ((packet.getTimeStamp() - (sfLastPacketTS) / (double) 1000000) > 1.0) {
+        if(((packet.getTimeStamp() - sfLastPacketTS)/(double)1000000)  > 1.0){
             sfCount++;
             long lastSFduration = packet.getTimeStamp() - sfAcHelper;
             updateActiveIdleTime(packet.getTimeStamp(), this.activityTimeout);


### PR DESCRIPTION
Verified and implemented (a rather crude) fix for bug identified in "Network Intrusion Detection:A Comprehensive Analysis of CIC-IDS2017" [https://www.scitepress.org/Papers/2022/107740/107740.pdf] 

As described in the paper: 
"The initial TCP window size in backward direction is updated with each packet received and therefore contains the last value instead of the initial one."
