### PR TITLE
tcp retransmission features + fix minor bug on bwd/fwd rst counts

### DIFF
--- a/src/main/java/cic/cs/unb/ca/jnetpcap/BasicPacketInfo.java
+++ b/src/main/java/cic/cs/unb/ca/jnetpcap/BasicPacketInfo.java
@@ -32,6 +32,8 @@ public class BasicPacketInfo {
 	private int icmpCode = -1;
 	private int icmpType = -1;
 
+	private TcpRetransmissionDTO tcpRetransmissionDTO;
+
 	public BasicPacketInfo(byte[] src, byte[] dst, int srcPort, int dstPort,
 			ProtocolEnum protocol, long timeStamp, IdGenerator generator) {
 		super();
@@ -271,5 +273,13 @@ public class BasicPacketInfo {
 
 	public void setIcmpType(int icmpType) {
 		this.icmpType = icmpType;
+	}
+
+	public TcpRetransmissionDTO tcpRetransmissionDTO(){
+		return this.tcpRetransmissionDTO;
+	}
+
+	public void setTcpRetransmissionDTO(TcpRetransmissionDTO tcpRetransmissionDTO) {
+		this.tcpRetransmissionDTO = tcpRetransmissionDTO;
 	}
 }

--- a/src/main/java/cic/cs/unb/ca/jnetpcap/FlowFeature.java
+++ b/src/main/java/cic/cs/unb/ca/jnetpcap/FlowFeature.java
@@ -100,9 +100,13 @@ public enum FlowFeature {
     icmp_code("ICMP Code", "IcmpC"),            // 86
     icmp_type("ICMP Type", "IcmpT"),            // 87
 
-    cum_tcp_time("Total TCP Flow Time", "TTFT"), //88
+    fwd_tcp_retrans("Fwd TCP Retrans. Count", "FwTcpRt"), //88
+    bwd_tcp_retrans("Bwd TCP Retrans. Count", "BwTcpRt"), //89
+    total_tcp_retrans("Total TCP Retrans. Count", "TotalTcpRt"), //90
+
+    cum_tcp_time("Total TCP Flow Time", "TTFT"), //91
 	
-	Label("Label","LBL",new String[]{"NeedManualLabel"});	//89
+	Label("Label","LBL",new String[]{"NeedManualLabel"});	//92
 
 
 	protected static final Logger logger = LoggerFactory.getLogger(FlowFeature.class);

--- a/src/main/java/cic/cs/unb/ca/jnetpcap/FlowGenerator.java
+++ b/src/main/java/cic/cs/unb/ca/jnetpcap/FlowGenerator.java
@@ -126,15 +126,12 @@ public class FlowGenerator {
                   // maintain the same source and destination information as the previous flow (since they're part of the
                   // same TCP connection).
                     BasicFlow newFlow = new BasicFlow(bidirectional,packet,flow.getSrc(),flow.getDst(),flow.getSrcPort(),
-                            flow.getDstPort(), this.flowActivityTimeOut);
+                            flow.getDstPort(), this.flowActivityTimeOut, flow.getTcpPacketsSeen());
 
                     long currDuration = flow.getCumulativeTcpConnectionDuration();
                     // get the gap between the last flow and the start of this flow
                     currDuration += (currentTimestamp - flow.getLastSeen());
                     newFlow.setCumulativeTcpConnectionDuration(currDuration);
-                    // Create a link to the previous tcp flow, this is required so that the final tcp flow duration
-                    // can be set correctly.
-                    newFlow.setPreviousTcpFlow(flow);
                     currentFlows.put(id, newFlow);
                 }
 

--- a/src/main/java/cic/cs/unb/ca/jnetpcap/PacketReader.java
+++ b/src/main/java/cic/cs/unb/ca/jnetpcap/PacketReader.java
@@ -8,6 +8,7 @@ import org.jnetpcap.nio.JMemory;
 import org.jnetpcap.packet.JHeader;
 import org.jnetpcap.packet.JHeaderPool;
 import org.jnetpcap.packet.PcapPacket;
+import org.jnetpcap.packet.format.FormatUtils;
 import org.jnetpcap.protocol.lan.Ethernet;
 import org.jnetpcap.protocol.network.Ip4;
 import org.jnetpcap.protocol.network.Ip6;
@@ -154,6 +155,12 @@ public class PacketReader {
 					packetInfo.setFlagRST(tcp.flags_RST());
 					packetInfo.setPayloadBytes(tcp.getPayloadLength());
 					packetInfo.setHeaderBytes(tcp.getHeaderLength());
+
+					TcpRetransmissionDTO tcpRetransmissionDTO = new TcpRetransmissionDTO(
+							this.ipv4.source(), tcp.seq(), tcp.ack(), tcp.getPayloadLength(),
+							tcp.window(), packet.getCaptureHeader().timestampInMicros());
+					packetInfo.setTcpRetransmissionDTO(tcpRetransmissionDTO);
+
 				}else if(packet.hasHeader(this.udp)){
 					packetInfo.setSrcPort(udp.source());
 					packetInfo.setDstPort(udp.destination());

--- a/src/main/java/cic/cs/unb/ca/jnetpcap/TcpRetransmissionDTO.java
+++ b/src/main/java/cic/cs/unb/ca/jnetpcap/TcpRetransmissionDTO.java
@@ -1,0 +1,67 @@
+package cic.cs.unb.ca.jnetpcap;
+
+import org.jnetpcap.packet.format.FormatUtils;
+
+import java.util.Arrays;
+
+public class TcpRetransmissionDTO {
+
+    private byte[] src;
+    private long seq;
+    private long ack;
+    private int payloadLength;
+
+    private int window;
+
+    private long timestamp;
+
+    /** The timestamp is used for debugging purposes, and does not serve as equality criteria.
+      * The current criteria seems sufficient for differentiating between retransmissions, but
+      * may require expansion in the future.
+     */
+    public TcpRetransmissionDTO(byte[] src, long seq, long ack, int payloadLength, int window, long timestamp) {
+        this.src = src;
+        this.seq = seq;
+        this.ack = ack;
+        this.payloadLength = payloadLength;
+        this.window = window;
+        this.timestamp = timestamp;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 17;
+        result = 31 * result + Arrays.hashCode(src);
+        result = 31 * result + (int) (seq ^ (seq >>> 32));
+        result = 31 * result + (int) (ack ^ (ack >>> 32));
+        result = 31 * result + payloadLength;
+        result = 31 * result + window;
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (!(obj instanceof TcpRetransmissionDTO)) {
+            return false;
+        }
+        TcpRetransmissionDTO tcpRetransmissionDTO = (TcpRetransmissionDTO) obj;
+        return Arrays.equals(src, tcpRetransmissionDTO.src) &&
+                seq == tcpRetransmissionDTO.seq &&
+                ack == tcpRetransmissionDTO.ack &&
+                payloadLength == tcpRetransmissionDTO.payloadLength &&
+                window == tcpRetransmissionDTO.window;
+    }
+    @Override
+    public String toString() {
+        return "TcpRetransmissionDTO{" +
+                "timestamp=" + DateFormatter.convertEpochTimestamp2String(timestamp) +
+                ", src=" + FormatUtils.ip(src) +
+                ", seq=" + seq +
+                ", ack=" + ack +
+                ", payloadLength=" + payloadLength +
+                ", window=" + window +
+                '}';
+    }
+
+}


### PR DESCRIPTION
To provide more differentiations between single packet flows arising from orphaned packets due to TCP timeout, I've added a crude mechanism to detect whether packets in a TCP flow could likely be a TCP retransmission packet. The logic works as follows:

- We store the unique combination of:
1. source ip (bytes)
2. Ack field
3. TCP seq field
4. The TCP window field was also added, as I noticed a "TCP window update" type TCP packets have (1,2,3) as identical.

During a Flow with TCP as the protocol, and detect whether this has been within a single TCP connection. Hashcode from the TCP header did not appear to work, since the packet timestamp is also incorporated into it. Note, this will only detect very obvious TCP retransmissions, and not others where more sophisticated analysis of the sequence number fields are required (for example, TCP spurious retransmissions), and for the purposes of the main problem this work is trying to solve, it should be sufficient. Future upgrades/improvements would be welcome to add more sophistication.