### PR TITLE
udp total connection time imp.

### DIFF
--- a/src/main/java/cic/cs/unb/ca/jnetpcap/BasicFlow.java
+++ b/src/main/java/cic/cs/unb/ca/jnetpcap/BasicFlow.java
@@ -86,7 +86,7 @@ public class BasicFlow {
     // The flow timeout is dependent on the user configuration and is unable to capture proper
     // context in extended TCP connections. This field will help identify whether a flow is
     // part of an extended TCP connection.
-    private long cumulativeTcpConnectionDuration;
+    private long cumulativeConnectionDuration;
 
     //To keep track of TCP connection teardown, or an RST packet in one direction.
     private TcpFlowState tcpFlowState;
@@ -154,7 +154,7 @@ public class BasicFlow {
         this.bFIN_cnt = 0;
         this.fHeaderBytes = 0L;
         this.bHeaderBytes = 0L;
-        this.cumulativeTcpConnectionDuration = 0L;
+        this.cumulativeConnectionDuration = 0L;
         this.tcpFlowState = null;
     }
 
@@ -1118,12 +1118,12 @@ public class BasicFlow {
         this.tcpFlowState = state;
     }
 
-    public long getCumulativeTcpConnectionDuration() {
-        return this.cumulativeTcpConnectionDuration;
+    public long getCumulativeConnectionDuration() {
+        return this.cumulativeConnectionDuration;
     }
 
-    public void setCumulativeTcpConnectionDuration(long cumTcpDuration) {
-        this.cumulativeTcpConnectionDuration = cumTcpDuration;
+    public void setCumulativeConnectionDuration(long cumTcpDuration) {
+        this.cumulativeConnectionDuration = cumTcpDuration;
     }
 
     public BasicFlow getPreviousTcpFlow() {
@@ -1189,6 +1189,7 @@ public class BasicFlow {
 
         if (bwdPktStats.getN() > 0L) {
             dump.append(bwdPktStats.getMax()).append(separator);                    //17
+
             dump.append(bwdPktStats.getMin()).append(separator);                    //18
             dump.append(bwdPktStats.getMean()).append(separator);                    //19
             dump.append(bwdPktStats.getStandardDeviation()).append(separator);        //20
@@ -1326,7 +1327,7 @@ public class BasicFlow {
         dump.append(icmpCode).append(separator);                                    // 86
         dump.append(icmpType).append(separator);                                    // 87
 
-        dump.append(cumulativeTcpConnectionDuration).append(separator);             //88
+        dump.append(cumulativeConnectionDuration).append(separator);             //88
         dump.append(getLabel());                                                    //89
 
 

--- a/src/main/java/cic/cs/unb/ca/jnetpcap/FlowFeature.java
+++ b/src/main/java/cic/cs/unb/ca/jnetpcap/FlowFeature.java
@@ -100,7 +100,7 @@ public enum FlowFeature {
     icmp_code("ICMP Code", "IcmpC"),            // 86
     icmp_type("ICMP Type", "IcmpT"),            // 87
 
-    cum_tcp_time("Total TCP Flow Time", "TTFT"), //88
+    cum_cnx_time("Total Connection Flow Time", "TCFT"), //88
 	
 	Label("Label","LBL",new String[]{"NeedManualLabel"});	//89
 


### PR DESCRIPTION
The premise for this change comes from analysing the sources of single packet flows. The objective is so that UDP flows stay connected, if they appear to be in a continuous dialogue, with the same source/dest direction beyond the flow timeout. The current mechanism results in some orphaned UDP packets becoming single packet udp flows that become detached as a result of a hard cut off from flow meter timeout value (the directions flipped - which is not accurate if they appear to be in continous dialogue).

The total connection time field is reset (i.e. the udp dialogue can be considered closed) when there is a period of inactivity (currently the flow timeout value is used).