### PR TITLE
Total connection time

### DIFF
--- a/src/main/java/cic/cs/unb/ca/jnetpcap/BasicFlow.java
+++ b/src/main/java/cic/cs/unb/ca/jnetpcap/BasicFlow.java
@@ -87,7 +87,7 @@ public class BasicFlow {
     // The flow timeout is dependent on the user configuration and is unable to capture proper
     // context in extended TCP connections. This field will help identify whether a flow is
     // part of an extended TCP connection.
-    private long cumulativeTcpConnectionDuration;
+    private long cumulativeConnectionDuration;
 
     //To keep track of TCP connection teardown, or an RST packet in one direction.
     private TcpFlowState tcpFlowState;
@@ -168,7 +168,7 @@ public class BasicFlow {
         this.bFIN_cnt = 0;
         this.fHeaderBytes = 0L;
         this.bHeaderBytes = 0L;
-        this.cumulativeTcpConnectionDuration = 0L;
+        this.cumulativeConnectionDuration = 0L;
         this.tcpFlowState = null;
         this.tcpPacketsSeen = new HashSet<TcpRetransmissionDTO>();
     }
@@ -1172,12 +1172,12 @@ public class BasicFlow {
         this.tcpFlowState = state;
     }
 
-    public long getCumulativeTcpConnectionDuration() {
-        return this.cumulativeTcpConnectionDuration;
+    public long getCumulativeConnectionDuration() {
+        return this.cumulativeConnectionDuration;
     }
 
-    public void setCumulativeTcpConnectionDuration(long cumTcpDuration) {
-        this.cumulativeTcpConnectionDuration = cumTcpDuration;
+    public void setCumulativeConnectionDuration(long cumTcpDuration) {
+        this.cumulativeConnectionDuration = cumTcpDuration;
     }
 
     public Set<TcpRetransmissionDTO> getTcpPacketsSeen() {
@@ -1391,9 +1391,8 @@ public class BasicFlow {
         dump.append(bwdTcpRetransCnt).append(separator);                                    // 89
         dump.append(fwdTcpRetransCnt+bwdTcpRetransCnt).append(separator);                                    // 90
 
-        dump.append(cumulativeTcpConnectionDuration).append(separator);             //91
+        dump.append(cumulativeConnectionDuration).append(separator);             //91
         dump.append(getLabel());                                                    //92
-
 
         return dump.toString();
     }

--- a/src/main/java/cic/cs/unb/ca/jnetpcap/FlowFeature.java
+++ b/src/main/java/cic/cs/unb/ca/jnetpcap/FlowFeature.java
@@ -103,9 +103,7 @@ public enum FlowFeature {
     fwd_tcp_retrans("Fwd TCP Retrans. Count", "FwTcpRt"), //88
     bwd_tcp_retrans("Bwd TCP Retrans. Count", "BwTcpRt"), //89
     total_tcp_retrans("Total TCP Retrans. Count", "TotalTcpRt"), //90
-
-    cum_tcp_time("Total TCP Flow Time", "TTFT"), //91
-	
+    cum_cnx_time("Total Connection Flow Time", "TCFT"), //91
 	Label("Label","LBL",new String[]{"NeedManualLabel"});	//92
 
 

--- a/src/main/java/cic/cs/unb/ca/jnetpcap/FlowGenerator.java
+++ b/src/main/java/cic/cs/unb/ca/jnetpcap/FlowGenerator.java
@@ -7,9 +7,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Set;
+import java.util.*;
 
 import static cic.cs.unb.ca.jnetpcap.Utils.LINE_SEP;
 
@@ -49,6 +47,8 @@ public class FlowGenerator {
     private long flowActivityTimeOut;
     private int finishedFlowCount;
 
+    private static final List<ProtocolEnum> TCP_UDP_LIST_FILTER = Arrays.asList(ProtocolEnum.TCP, ProtocolEnum.UDP);
+
     public FlowGenerator(boolean bidirectional, long flowTimeout, long activityTimeout) {
         super();
         this.bidirectional = bidirectional;
@@ -85,7 +85,8 @@ public class FlowGenerator {
                 id = packet.bwdFlowId();
             }
 
-            flow = currentFlows.get(id);
+            flow = currentFlows.get(id); //The existing (original flow) that the packet is associated with
+
             // Flow finished due flowtimeout:
             // 1.- we move the flow to finished flow list
             // 2.- we eliminate the flow from the current flow list
@@ -94,10 +95,10 @@ public class FlowGenerator {
                     ((flow.getTcpFlowState() == TcpFlowState.READY_FOR_TERMINATION) && packet.hasFlagSYN())) {
 
                 // set cumulative flow time if TCP packet
-                if (flow.getProtocol() == ProtocolEnum.TCP) {
-                    long currDuration = flow.getCumulativeTcpConnectionDuration();
+                if(TCP_UDP_LIST_FILTER.contains(flow.getProtocol())) {
+                    long currDuration = flow.getCumulativeConnectionDuration();
                     currDuration += flow.getFlowDuration();
-                    flow.setCumulativeTcpConnectionDuration(currDuration);
+                    flow.setCumulativeConnectionDuration(currDuration);
                 }
 
                 if (mListener != null) {
@@ -106,12 +107,25 @@ public class FlowGenerator {
                     finishedFlows.put(getFlowCount(), flow);
                     //flow.endActiveIdleTime(currentTimestamp,this.flowActivityTimeOut, this.flowTimeOut, false);
                 }
-                currentFlows.remove(id);
+                currentFlows.remove(id);  // Remove the expired flow from the current flow list
 
-                // If the original flow is set for termination, or the flow is not a tcp connection, create a new flow
+                // Create a new UDP flow if activity time difference between the current UDP packet, and the last
+                // packet in the previous flow is greater than the flow activity timeout. This is to soften the issue
+                // with hard separation UDP flows that are likely part of the same "dialogue", which can lead to single
+                // packet flows with the hard flow time out cutoff. The concept of a "dialogue" is not well-defined in
+                // UDP, like TCP, so we assume that if the activity time difference between the current packet and the
+                // last packet in the previous flow is greater than the flow activity timeout, then the current packet
+                // is part of a new "dialogue".
+                boolean createNewUdpFlow =
+                        (flow.getProtocol() == ProtocolEnum.UDP && currentTimestamp - flow.getLastSeen() > this.flowTimeOut);
+
+                // If the original flow is set for termination, or the flow is not a tcp connection, create a new flow,
+                // and place it into the currentFlows list
                 // Having a SYN packet and no ACK packet means it's the first packet in a new flow
-                if ((flow.getTcpFlowState() == TcpFlowState.READY_FOR_TERMINATION && packet.hasFlagSYN())
-                        || packet.getProtocol() != ProtocolEnum.TCP) {
+                if ((flow.getTcpFlowState() == TcpFlowState.READY_FOR_TERMINATION && packet.hasFlagSYN())      // tcp flow is ready for termination
+                        || createNewUdpFlow                                                                    // udp packet is not part of current "dialogue"
+                        || !TCP_UDP_LIST_FILTER.contains(packet.getProtocol())                                 // other protocols
+                ) {
                     if(packet.hasFlagSYN() && packet.hasFlagACK()) {
                         // create new flow, switch direction - we assume the PCAP file had a mistake where SYN-ACK arrived before SYN packet
                         currentFlows.put(id, new BasicFlow(bidirectional,packet,packet.getDst(),packet.getSrc(),packet.getDstPort(),
@@ -124,14 +138,14 @@ public class FlowGenerator {
                 } else {
                   // Otherwise, the previous flow was likely terminated because of a timeout, and the new flow has to
                   // maintain the same source and destination information as the previous flow (since they're part of the
-                  // same TCP connection).
+                  // same TCP connection or UDP "dialogue".
                     BasicFlow newFlow = new BasicFlow(bidirectional,packet,flow.getSrc(),flow.getDst(),flow.getSrcPort(),
                             flow.getDstPort(), this.flowActivityTimeOut, flow.getTcpPacketsSeen());
 
-                    long currDuration = flow.getCumulativeTcpConnectionDuration();
+                    long currDuration = flow.getCumulativeConnectionDuration();
                     // get the gap between the last flow and the start of this flow
                     currDuration += (currentTimestamp - flow.getLastSeen());
-                    newFlow.setCumulativeTcpConnectionDuration(currDuration);
+                    newFlow.setCumulativeConnectionDuration(currDuration);
                     currentFlows.put(id, newFlow);
                 }
 
@@ -201,7 +215,7 @@ public class FlowGenerator {
                 flow.addPacket(packet);
                 currentFlows.put(id, flow);
             }
-        } else {
+        } else { // not part of an existing flow
 
             if(packet.hasFlagSYN() && packet.hasFlagACK()){
                 currentFlows.put(packet.bwdFlowId(), new BasicFlow(bidirectional,packet,packet.getDst(),packet.getSrc(),packet.getDstPort(),
@@ -309,8 +323,8 @@ public class FlowGenerator {
             for (BasicFlow flow : currentFlows.values()) {
                 if (flow.packetCount() >= 1) {
 
-                    if (flow.getProtocol() == ProtocolEnum.TCP) {
-                        flow = updateTcpCxnDuration(flow);
+                    if (TCP_UDP_LIST_FILTER.contains(flow.getProtocol())) {
+                        flow = updateTcpUdpCxnDuration(flow);
                     }
 
                     output.write((flow.dumpFlowBasedFeaturesEx() + LINE_SEP).getBytes());
@@ -336,11 +350,11 @@ public class FlowGenerator {
     }
 
 
-    private BasicFlow updateTcpCxnDuration(BasicFlow tcpFlow) {
-        long currDuration = tcpFlow.getCumulativeTcpConnectionDuration();
-        currDuration += tcpFlow.getFlowDuration();
-        tcpFlow.setCumulativeTcpConnectionDuration(currDuration);
-        return tcpFlow;
+    private BasicFlow updateTcpUdpCxnDuration(BasicFlow tcpUdpFlow) {
+        long currDuration = tcpUdpFlow.getCumulativeConnectionDuration();
+        currDuration += tcpUdpFlow.getFlowDuration();
+        tcpUdpFlow.setCumulativeConnectionDuration(currDuration);
+        return tcpUdpFlow;
     }
 
     private int getFlowCount() {


### PR DESCRIPTION
The premise for this change comes from analysing the sources of single packet flows. The objective is so that UDP flows stay connected, if they appear to be in a continuous dialogue, with the same source/dest direction beyond the flow timeout. The current mechanism results in some orphaned UDP packets becoming single packet udp flows that become detached as a result of a hard cut off from flow meter timeout value (the directions flipped - which is not accurate if they appear to be in continous dialogue).

The total connection time field is reset (i.e. the udp dialogue can be considered closed) when there is a period of inactivity (currently the flow timeout value is used).