### PR TITLE
TCP Retransmission bug if the packet being retransmitted is the first packet in the flow

### DIFF
--- a/src/main/java/cic/cs/unb/ca/jnetpcap/BasicFlow.java
+++ b/src/main/java/cic/cs/unb/ca/jnetpcap/BasicFlow.java
@@ -189,7 +189,6 @@ public class BasicFlow {
         updateFlowBulk(packet);
 
         checkFlags(packet);
-        handleTcpRetransmissionFields(packet);
 
         this.endActiveTime = packet.getTimeStamp();
         this.flowStartTime = packet.getTimeStamp();
@@ -249,6 +248,7 @@ public class BasicFlow {
         this.icmpCode = packet.getIcmpCode();
         this.icmpType = packet.getIcmpType();
         this.flowId = packet.getFlowId();
+        handleTcpRetransmissionFields(packet);
     }
 
     /***


### PR DESCRIPTION
It depends on the protocol field being set, which does not happen until the end of the method.